### PR TITLE
Add fail trigger in TF2 graph mode

### DIFF
--- a/src/latte/metrics/keras/wrapper.py
+++ b/src/latte/metrics/keras/wrapper.py
@@ -13,9 +13,19 @@ import numpy as np
 
 from ...metrics.base import LatteMetric
 
+
+def safe_numpy(t: tf.Tensor) -> np.ndarray:
+    if hasattr(t, 'numpy'):
+        return t.numpy()
+    else:
+        raise RuntimeError(
+            "This metric requires an EagerTensor. Please make sure you are in an eager execution mode. If you are using Keras API, compile the model with the flag `run_eagerly=True`."
+        )
+
+
 def tf_to_numpy(args, kwargs):
-    args = [a.numpy() for a in args]
-    kwargs = {k: kwargs[k].numpy() for k in kwargs}
+    args = [safe_numpy(a) for a in args]
+    kwargs = {k: safe_numpy(kwargs[k]) for k in kwargs}
 
     return args, kwargs
 

--- a/tests/metrics/keras/test_wrapper.py
+++ b/tests/metrics/keras/test_wrapper.py
@@ -9,6 +9,8 @@ try:
     has_tf = True
 except:
     has_tf = False
+    
+from importlib import reload
 
 
 @pytest.mark.skipif(has_tf, reason="requires missing tensorflow")
@@ -34,10 +36,17 @@ class DummyMetric(LatteMetric):
 
 @pytest.mark.skipif(not has_tf, reason="requires tensorflow")
 class TestConvert:
+    def test_graph_mode(self):
+        from latte.metrics.keras.wrapper import safe_numpy
+        
+        with tf.Graph().as_default():
+            with pytest.raises(RuntimeError, match="This metric requires an EagerTensor. Please make sure you are in an eager execution mode. If you are using Keras API, compile the model with the flag `run_eagerly=True`."):
+                x = tf.random.uniform(shape=(16,))
+                safe_numpy(x)
+        
+    
     def test_tf_to_np(self):
         from latte.metrics.keras.wrapper import tf_to_numpy
-
-        tf.random.uniform
 
         a1 = tf.random.uniform(shape=(16,))
         a2 = tf.random.uniform(shape=(16,))


### PR DESCRIPTION
Implements option 1 from [#19 ](https://github.com/karnwatcharasupat/latte/issues/19#issuecomment-1004820296_).

Triggers a RuntimeError upon encountering a non-eager TF tensor. 