### PR TITLE
Working with Python 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 project_urls =
     Bug Tracker = https://github.com/karnwatcharasupat/latte/issues
 
@@ -25,7 +26,7 @@ packages = find:
 install_requires =
     numpy>=1.18
     scikit-learn>=1.0
-python_requires = >=3.7, <3.10
+python_requires = >=3.7
 package_dir =
     = src
 


### PR DESCRIPTION
Hello,
The current setup.cfg prevents us from installing this package on python 3.10.
In that past, there might have been some dependency issues - but now it's working fine after I modified it.
If there is not known issue, it would be great to update the file in the main repo.